### PR TITLE
fix: exec builtins before PATH and change get_path logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 CC		= cc
 CFLAGS	= -Wall -Wextra
 CFLAGS	+= -Wshadow -Wpedantic -Wuninitialized -Wmissing-include-dirs -Wundef -Winvalid-pch
-CFLAGS	+= -Winit-self -Wswitch-enum -Wswitch-default -Wformat=2 -Wformat-nonliteral -Wformat-security -Wformat-y2k
+CFLAGS	+= -Winit-self -Wswitch-enum -Wswitch-default -Wformat-security -Wformat-y2k
 CFLAGS	+= -Wdouble-promotion -Wfloat-equal -Wpointer-arith
 CFLAGS	+= -MMD -MP
 INCLUDE	= -I$(H_DIR) -I$(LIBFT_DIR)/$(H_DIR)

--- a/src/execution/exec.c
+++ b/src/execution/exec.c
@@ -11,9 +11,15 @@
 /* ************************************************************************** */
 
 #include "execution.h"
-#include <errno.h>
 
 extern t_minishell	g_minishell;
+
+static void	exit_error(const char *format, const char *s, int code)
+{
+	printf(format, s);
+	ft_lstclear(&g_minishell.envs, free_env);
+	exit(code);
+}
 
 int	exec(char **av, char *cmd)
 {
@@ -24,12 +30,10 @@ int	exec(char **av, char *cmd)
 		return (-1);
 	if (ret == 0)
 	{
+		if (cmd == NULL)
+			exit_error("minishell: %s: command not found\n", av[0], 127);
 		if (execve(cmd, av, NULL) == -1)
-		{
-			printf("%s: command not found\n", av[0]);
-			ft_lstclear(&g_minishell.envs, free_env);
-			exit(127);
-		}
+			exit_error("minishell: %s: Permission denied\n", cmd, 126);
 	}
 	return (ret);
 }

--- a/src/execution/get_path.c
+++ b/src/execution/get_path.c
@@ -18,8 +18,10 @@ char	*get_path(char **path, char *cmd)
 {
 	int		i;
 	char	*tmp;
+	char	*cmd_path;
 
 	i = 0;
+	cmd_path = NULL;
 	while (path[i])
 	{
 		tmp = path[i];
@@ -29,10 +31,14 @@ char	*get_path(char **path, char *cmd)
 		path[i] = ft_strjoin(tmp, cmd);
 		free(tmp);
 		if (access(path[i], F_OK) == 0)
-			return (path[i]);
+		{
+			cmd_path = path[i];
+			if (access(path[i], X_OK) == 0)
+				return (path[i]);
+		}
 		i++;
 	}
-	return (NULL);
+	return (cmd_path);
 }
 
 void	free_path(char **path)
@@ -51,25 +57,21 @@ void	free_path(char **path)
 char	*get_path_cmd(char *cmd)
 {
 	t_env	*env;
-	t_list	*lst;
 	char	**path;
-	char	*tmp;
+	char	*cmd_path;
 
-	env = NULL;
-	lst = g_minishell.envs;
-	while (lst != NULL)
-	{
-		env = lst->content;
-		if (env == get_env_el("PATH"))
-			break ;
-		lst = lst->next;
-	}
-	path = ft_split(env->value, ':');
-	if (get_path(path, cmd) == NULL)
+	env = get_env_el("PATH");
+	if (!env)
 		return (NULL);
-	tmp = ft_strdup(get_path(path, cmd));
+	path = ft_split(env->value, ':');
+	if (!path)
+		exit(12);
+	cmd_path = get_path(path, cmd);
+	if (cmd_path == NULL)
+		return (NULL);
+	cmd_path = ft_strdup(cmd_path);
+	if (!cmd_path)
+		exit(12);
 	free_path(path);
-	if (tmp != NULL)
-		return (tmp);
-	return (NULL);
+	return (cmd_path);
 }

--- a/src/execution/get_path.c
+++ b/src/execution/get_path.c
@@ -14,6 +14,22 @@
 
 extern t_minishell	g_minishell;
 
+static char	*concat_path_command(char *path, char *cmd)
+{
+	char	*tmp;
+	char	*cmd_path;
+
+	if (path[ft_strlen(path) - 1] != '/')
+	{
+		tmp = ft_strjoin(path, "/");
+		cmd_path = ft_strjoin(tmp, cmd);
+		free(tmp);
+	}
+	else
+		cmd_path = ft_strjoin(path, cmd);
+	return (cmd_path);
+}
+
 char	*get_path(char **path, char *cmd)
 {
 	int		i;
@@ -24,18 +40,19 @@ char	*get_path(char **path, char *cmd)
 	cmd_path = NULL;
 	while (path[i])
 	{
-		tmp = path[i];
-		path[i] = ft_strjoin(tmp, "/");
-		free(tmp);
-		tmp = path[i];
-		path[i] = ft_strjoin(tmp, cmd);
-		free(tmp);
-		if (access(path[i], F_OK) == 0)
+		tmp = concat_path_command(path[i], cmd);
+		if (!tmp)
+			exit(12);
+		if (access(tmp, F_OK) == 0)
 		{
-			cmd_path = path[i];
-			if (access(path[i], X_OK) == 0)
-				return (path[i]);
+			if (cmd_path)
+				free(cmd_path);
+			cmd_path = tmp;
+			if (access(cmd_path, X_OK) == 0)
+				return (cmd_path);
 		}
+		else
+			free(tmp);
 		i++;
 	}
 	return (cmd_path);
@@ -67,11 +84,8 @@ char	*get_path_cmd(char *cmd)
 	if (!path)
 		exit(12);
 	cmd_path = get_path(path, cmd);
+	free_path(path);
 	if (cmd_path == NULL)
 		return (NULL);
-	cmd_path = ft_strdup(cmd_path);
-	if (!cmd_path)
-		exit(12);
-	free_path(path);
 	return (cmd_path);
 }

--- a/src/execution/pipe.c
+++ b/src/execution/pipe.c
@@ -74,12 +74,14 @@ int	pipex(int fdin, int tpout, t_list *command)
 		}
 		dup2(fdout, 1);
 		close(fdout);
-		tmp = get_path_cmd(cmd->args[0]);
 		if (builtins(nbr_args(cmd->args), cmd->args) == 2)
+		{
+			tmp = get_path_cmd(cmd->args[0]);
 			cmd->pid = exec(cmd->args, tmp);
+			free(tmp);
+		}
 		else
 			cmd->pid = 0;
-		free(tmp);
 		command = command->next;
 	}
 	return (cmd->pid);


### PR DESCRIPTION
Close #6

The first commit 184f52891a10e6ec4ad87b95bf52c549c303372a changed the order of execution to execute builtins before checking in PATH, and simplify the `get_path_cmd` logic, and fixed the command not found `NULL` pointer `ft_strdup`.

Also changed in `get_path` to handle the case where there are two files in the PATH with the same name, the first one is not executable but the second one is. An example:
PATH:
- /bin
- /usr/bin

in /bin there is the file `loc` that is not executable
in /usr/bin there is the file `loc` that IS executable
minishell should execute the second `loc` because it can execute it and not stop at the first `loc` found

The second commit 394b976b9bbfb220c9ca07b9b0246c56a4fb59ae makes the difference between a `command not found` and a `permission denied` found the file in PATH, with the according error message and error codes.

The third commit 3735386ae415fac1ea2c40be49e760d061a844e0 change the `get_path` logic to not modify the `char **path` arg because not that good :/ (can't call the function 2 times in a row if `path` is modified), also fix the problem of a path that already have a `/`, need to check it and not add it.

Pls review this is your code 😝