### PR TITLE
fix: newline after all ctrl+c after ctrl+c on heredoc

### DIFF
--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -27,5 +27,6 @@
 
 void	handle_signals(void);
 void	handle_signals_heredoc(void);
+void	handle_signals_heredoc_child(void);
 
 #endif

--- a/src/signal.c
+++ b/src/signal.c
@@ -11,6 +11,7 @@
 /* ************************************************************************** */
 
 #include "minishell.h"
+#include <signal.h>
 
 extern t_minishell	g_minishell;
 
@@ -23,14 +24,6 @@ static void	sighandler(int signum)
 	rl_redisplay();
 }
 
-static void	sighandler_heredoc(int signum)
-{
-	(void)signum;
-	printf("\n");
-	close(STDIN_FILENO);
-	g_minishell.signal = 1;
-}
-
 void	handle_signals(void)
 {
 	signal(SIGINT, &sighandler);
@@ -40,5 +33,11 @@ void	handle_signals(void)
 
 void	handle_signals_heredoc(void)
 {
-	signal(SIGINT, &sighandler_heredoc);
+	signal(SIGINT, SIG_IGN);
+}
+
+void	handle_signals_heredoc_child(void)
+{
+	signal(SIGINT, SIG_DFL);
+	signal(SIGQUIT, SIG_DFL);
 }


### PR DESCRIPTION
Close #11 
Really weird bug, seems to be due to `readline` function somehow but not able to figure out why. So changing strategy and isolating heredoc handling inside a fork to make it simpler