### PR TITLE
fix: empty or unexisting env variable causes crashes

### DIFF
--- a/incl/parser.h
+++ b/incl/parser.h
@@ -47,5 +47,6 @@ int				handle_heredoc(char *stop);
 t_command		*create_command(t_token *token);
 int				process_rd(t_token *t, t_command **c, t_list **ts);
 bool			is_directory(const char *path);
+bool			is_empty(const char *s);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -35,20 +35,6 @@ static char	*get_line(void)
 	return (line);
 }
 
-static bool	is_empty(char *s)
-{
-	int	i;
-
-	i = 0;
-	while (s[i])
-	{
-		if (!ft_isspace(s[i]))
-			return (false);
-		i++;
-	}
-	return (true);
-}
-
 static void	routine(void)
 {
 	char	*line;

--- a/src/parser/parse.c
+++ b/src/parser/parse.c
@@ -24,8 +24,31 @@ void	free_token(void *ptr)
 	}
 }
 
-/* TODO make an exit function that clear g_minishell
- */
+void	lst_remove_empty(t_list **lst)
+{
+	t_list	*tokens;
+	t_list	*prev;
+	t_token	*token;
+
+	prev = NULL;
+	tokens = *lst;
+	while (tokens)
+	{
+		token = tokens->content;
+		if (token->value && token->value[0] == 0)
+		{
+			if (prev)
+				prev->next = tokens->next;
+			else
+				*lst = tokens->next;
+			free_token(token);
+		}
+		else
+			prev = tokens;
+		tokens = tokens->next;
+	}
+}
+
 t_list	*parse_line(char *line)
 {
 	t_list	*tokens;
@@ -38,6 +61,7 @@ t_list	*parse_line(char *line)
 		return (ft_lstclear(&tokens, &free_token), NULL);
 	if (lst_remove_quotes(tokens) == -1)
 		return (ft_lstclear(&tokens, &free_token), NULL);
+	lst_remove_empty(&tokens);
 	if (!valid_syntax(tokens))
 		return (ft_lstclear(&tokens, &free_token), NULL);
 	commands = tokens_to_commands(tokens);

--- a/src/parser/substitute.c
+++ b/src/parser/substitute.c
@@ -48,7 +48,10 @@ static char	*get_env_value(char *name)
 		return (ft_itoa(g_minishell.exit_status));
 	env = get_env_el(name);
 	if (env)
+	{
 		env_value = ft_strdup(env->value);
+		exit(12);
+	}
 	return (env_value);
 }
 
@@ -72,7 +75,7 @@ static char	*replace_env(char *s, char *old, uint *end, uint *start)
 		return (free(env), old);
 	env_value = get_env_value(env);
 	if (!env_value)
-		exit(12);
+		env_value = ft_strdup("");
 	old = ft_concat(old, env_value);
 	if (!old)
 		exit(12);

--- a/src/utils.c
+++ b/src/utils.c
@@ -51,3 +51,17 @@ int	is_quote(int c)
 		return (true);
 	return (false);
 }
+
+bool	is_empty(const char *s)
+{
+	int	i;
+
+	i = 0;
+	while (s[i])
+	{
+		if (!ft_isspace(s[i]))
+			return (false);
+		i++;
+	}
+	return (true);
+}


### PR DESCRIPTION
Close #37 