### PR TITLE
Non iterractive behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ SRCS	+=	builtins/echo.c \
 			parser/create_command.c \
 			parser/process_rd.c \
 			parser/is_rdout.c \
+			print_error.c \
 			readinput.c \
 			signal.c \
 			signal2.c \

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,7 @@ SRCS	+=	builtins/echo.c \
 			parser/create_command.c \
 			parser/process_rd.c \
 			parser/is_rdout.c \
+			readinput.c \
 			signal.c \
 			signal2.c \
 			execution/exec.c \

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -25,6 +25,7 @@
 # include "execution.h"
 # include "struct.h"
 
+char	*readinput(const char *prompt);
 void	handle_signals(void);
 void	handle_signals_exec(void);
 void	handle_signals_heredoc(void);

--- a/incl/minishell.h
+++ b/incl/minishell.h
@@ -30,5 +30,6 @@ void	handle_signals(void);
 void	handle_signals_exec(void);
 void	handle_signals_heredoc(void);
 void	reset_signals(void);
+void	print_error(const char *format, const char *arg1, const char *arg2);
 
 #endif

--- a/incl/parser.h
+++ b/incl/parser.h
@@ -26,8 +26,6 @@
 # define ERROR_MALLOC 1
 # define NO_ERROR 0
 
-# define FILE_ERROR_MSG "minishell: %s: No such file or directory\n"
-
 int				is_operator(char c);
 void			free_token(void *ptr);
 t_list			*parse_line(char *line);

--- a/incl/parser.h
+++ b/incl/parser.h
@@ -43,7 +43,7 @@ void			print_commands(t_list *commands);
 int				valid_syntax(t_list *tokens);
 void			free_command(void *ptr);
 t_list			*tokens_to_commands(t_list *tokens);
-int				handle_heredoc(char *stop);
+int				handle_heredoc(const char *stop);
 t_command		*create_command(t_token *token);
 int				process_rd(t_token *t, t_command **c, t_list **ts);
 bool			is_directory(const char *path);

--- a/incl/struct.h
+++ b/incl/struct.h
@@ -27,6 +27,7 @@ typedef struct s_minishell
 	int		exit_status;
 	void	*commands;
 	t_list	*envs;
+	char	*prompt;
 }				t_minishell;
 
 typedef enum e_token_type

--- a/src/builtins/cd.c
+++ b/src/builtins/cd.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "builtins.h"
+#include "minishell.h"
 
 extern t_minishell	g_minishell;
 
@@ -37,15 +37,15 @@ int	cd(int ac, char **av)
 		if (home && chdir(home) == -1)
 			return (1);
 		else if (!home)
-			return (printf("minishell: cd: HOME not set\n"), 1);
+			return (print_error("cd: HOME not set", NULL, NULL), 1);
 	}
 	else if (ac > 2)
-		return (printf("minishell: cd: too many arguments\n"), 1);
+		return (print_error("cd: too many arguments", NULL, NULL), 1);
 	else if (ac == 2)
 	{
 		if (chdir(av[1]) == -1)
 		{
-			printf("minishell: cd: %s: No such file or directory\n", av[1]);
+			print_error("cd: %s: No such file or directory", av[1], NULL);
 			return (1);
 		}
 	}

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -90,14 +90,14 @@ int	my_exit(int ac, char **av)
 		value = atoi_exit(av[1]);
 		if (!verif_number(av) || !is_valid(av))
 		{
-			printf("minishell: exit: %s: numeric argument required\n", av[1]);
+			print_error("exit: %s: numeric argument required", av[1], NULL);
 			free_exit(2);
 		}
 		status = value;
 	}
 	if (ac > 2)
 	{
-		printf("minishell: exit: too many arguments\n");
+		print_error("exit: too many arguments", NULL, NULL);
 		g_minishell.exit_status = 1;
 		return (1);
 	}

--- a/src/builtins/export.c
+++ b/src/builtins/export.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "builtins.h"
+#include "minishell.h"
 
 extern t_minishell	g_minishell;
 
@@ -22,7 +22,7 @@ static char	*print_name(char *av)
 	while (av[i])
 		i++;
 	av[i] = '\0';
-	printf("export: not an identifier: %s\n", av);
+	print_error("export: `%s': not an identifier", av, NULL);
 	return (av);
 }
 
@@ -64,7 +64,7 @@ int	valid_name(char *av)
 	{
 		if ((av[0] > '0' && av[0] < '9') || !check_char(av))
 		{
-			printf("minishell: export: `%s': not a valid identifier\n", av);
+			print_error("%s: `%s': not a valid identifier", "export", av);
 			return (1);
 		}
 		i++;

--- a/src/execution/exec.c
+++ b/src/execution/exec.c
@@ -16,7 +16,7 @@ extern t_minishell	g_minishell;
 
 static void	exit_error(const char *format, const char *s, int code, char *cmd)
 {
-	printf(format, s);
+	print_error(format, s, NULL);
 	ft_lstclear(&g_minishell.envs, free_env);
 	ft_lstclear((t_list **)&g_minishell.commands, &free_command);
 	if (cmd)
@@ -42,17 +42,16 @@ void	exec_or_error(char *cmd, char **av)
 	struct stat	buf;
 
 	if (cmd == NULL || ft_strlen(av[0]) == 0)
-		exit_error("minishell: %s: command not found\n", av[0], 127, cmd);
+		exit_error("%s: command not found", av[0], 127, cmd);
 	if (stat(cmd, &buf) != -1)
 	{
 		if (S_ISDIR(buf.st_mode))
-			exit_error("minishell: %s: Is a directory\n", av[0], 126, cmd);
+			exit_error("%s: Is a directory", av[0], 126, cmd);
 	}
 	if (access(cmd, F_OK) == -1 && (ft_strncmp(av[0], "./", 2) == 0
 			|| ft_strncmp(av[0], "../", 2) == 0
 			|| ft_strncmp(av[0], "/", 1) == 0))
-		exit_error("minishell: %s: No such file or directory\n",
-			av[0], 127, cmd);
+		exit_error("%s: No such file or directory", av[0], 127, cmd);
 	if (builtins(nbr_args(av), av) == 0)
 		ft_lstclear(&g_minishell.envs, free_env);
 	else
@@ -60,7 +59,7 @@ void	exec_or_error(char *cmd, char **av)
 		tab = list_to_tab(g_minishell.envs);
 		execve(cmd, av, tab);
 		free_tab(tab);
-		exit_error("minishell: %s: Permission denied\n", cmd, 126, cmd);
+		exit_error("%s: Permission denied", cmd, 126, cmd);
 	}
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -22,10 +22,8 @@ static void	usage(char *prog_name)
 static char	*get_line(void)
 {
 	char	*line;
-	char	*prompt;
 
-	prompt = "minishell$ ";
-	line = readline(prompt);
+	line = readinput(g_minishell.prompt);
 	if (!line)
 		return (NULL);
 	else if (*line)
@@ -64,6 +62,7 @@ static void	init_minishell(char **envp)
 	g_minishell.signal = 0;
 	g_minishell.exit_status = 0;
 	g_minishell.commands = NULL;
+	g_minishell.prompt = "minishell$ ";
 }
 
 int	main(int ac, char **av, char **envp)

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ t_minishell	g_minishell;
 
 static void	usage(char *prog_name)
 {
-	printf("%s: too many arguments\n", prog_name);
+	print_error("%s: too many arguments\n", prog_name, NULL);
 }
 
 static char	*get_line(void)

--- a/src/parser/handle_open_error.c
+++ b/src/parser/handle_open_error.c
@@ -10,18 +10,18 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "minishell.h"
 
 int	handle_open_error(const char *s, int type)
 {
 	if ((type == RD_IN && access(s, F_OK)) || (is_rdout(type) && s[0] == 0))
-		printf("minishell: %s: No such file or directory\n", s);
+		print_error("%s: No such file or directory", s, NULL);
 	else if (type == RD_IN && access(s, R_OK))
-		printf("minishell: %s: Permission denied\n", s);
+		print_error("%s: Permission denied", s, NULL);
 	else if (is_rdout(type) && access(s, F_OK) == 0 && access(s, W_OK) != 0)
-		printf("minishell: %s: Permission denied\n", s);
+		print_error("%s: Permission denied", s, NULL);
 	else if (is_rdout(type) && is_directory(s))
-		printf("minishell: %s: Is a directory\n", s);
+		print_error("%s: Is a directory", s, NULL);
 	else
 		return (0);
 	return (1);

--- a/src/parser/lst_remove_quotes.c
+++ b/src/parser/lst_remove_quotes.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "minishell.h"
 
 static bool	is_quotes_valid(const char *s)
 {
@@ -42,7 +42,7 @@ int	lst_remove_quotes(t_list *lst)
 		token = lst->content;
 		if (!is_quotes_valid(token->value))
 		{
-			printf("minishell: unclosed quote\n");
+			print_error("unclosed quote", NULL, NULL);
 			return (-1);
 		}
 		remove_quotes(token->value);

--- a/src/parser/process_rd.c
+++ b/src/parser/process_rd.c
@@ -10,7 +10,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "minishell.h"
 
 extern t_minishell	g_minishell;
 
@@ -41,7 +41,7 @@ static int	open_fd(t_redirect_type type, t_token *name)
 			fd = open(s, get_open_flag(type), 0644);
 		if (fd == -1)
 		{
-			printf("minishell: %s: No such file or directory\n", s);
+			print_error("%s: No such file or directory", s, NULL);
 			fd = -2;
 		}
 		if (fd == -2)

--- a/src/parser/valid_syntax.c
+++ b/src/parser/valid_syntax.c
@@ -10,7 +10,9 @@
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "parser.h"
+#include "minishell.h"
+
+extern t_minishell	g_minishell;
 
 static int	is_token_redirect(t_token_type type)
 {
@@ -49,7 +51,8 @@ static void	print_syntax_error(t_list *lst)
 		token = lst->content;
 		token_value = token->value;
 	}
-	printf("minishell: syntax error near unexpected token `%s'\n", token_value);
+	print_error("syntax error near unexpected token `%s'", token_value, NULL);
+	g_minishell.exit_status = 2;
 }
 
 int	valid_syntax(t_list *tokens)

--- a/src/print_error.c
+++ b/src/print_error.c
@@ -1,7 +1,7 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   readinput.c                                        :+:      :+:    :+:   */
+/*   print_error.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: apigeon <apigeon@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
@@ -12,25 +12,20 @@
 
 #include "minishell.h"
 
-extern t_minishell	g_minishell;
-
-char	*readinput(const char *prompt)
+void	print_error(const char *format, const char *arg1, const char *arg2)
 {
-	size_t	last;
-	char	*line;
+	int	save;
 
-	line = NULL;
-	if (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO))
-		line = readline(prompt);
+	save = dup(STDOUT_FILENO);
+	dup2(STDERR_FILENO, STDOUT_FILENO);
+	printf("minishell: ");
+	if (arg2)
+		printf(format, arg1, arg2);
+	else if (arg1)
+		printf(format, arg1);
 	else
-	{
-		line = get_next_line(STDIN_FILENO);
-		if (line)
-		{
-			last = ft_strlen(line) - 1;
-			if (last >= 0 && line[last] == '\n')
-				line[last] = 0;
-		}
-	}
-	return (line);
+		printf("%s", format);
+	printf("\n");
+	dup2(save, STDOUT_FILENO);
+	close(save);
 }

--- a/src/readinput.c
+++ b/src/readinput.c
@@ -1,0 +1,38 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   readinput.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: apigeon <apigeon@student.42.fr>            +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/10/19 18:20:54 by apigeon           #+#    #+#             */
+/*   Updated: 2023/01/21 14:43:35 by tperes           ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+extern t_minishell	g_minishell;
+
+char	*readinput(const char *prompt)
+{
+	size_t	last;
+	char	*line;
+
+	line = NULL;
+	if (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO))
+		line = readline(prompt);
+	else
+	{
+		if (isatty(STDIN_FILENO))
+			printf("%s", prompt);
+		line = get_next_line(STDIN_FILENO);
+		if (line)
+		{
+			last = ft_strlen(line) - 1;
+			if (last >= 0 && line[last] == '\n')
+				line[last] = 0;
+		}
+	}
+	return (line);
+}

--- a/src/signal.c
+++ b/src/signal.c
@@ -17,10 +17,13 @@ extern t_minishell	g_minishell;
 static void	sighandler(int signum)
 {
 	(void)signum;
-	printf("\n");
-	rl_on_new_line();
-	rl_replace_line("", 0);
-	rl_redisplay();
+	if (isatty(STDOUT_FILENO))
+	{
+		printf("\n");
+		rl_on_new_line();
+		rl_replace_line("", 0);
+		rl_redisplay();
+	}
 	g_minishell.exit_status = 1;
 }
 

--- a/tests
+++ b/tests
@@ -1,0 +1,8 @@
+echo "exit_code ->$? user ->$USER home -> $HOME"
+echo 'exit_code ->$? user ->$USER home -> $HOME'
+export =
+exit 123
+exit 298
+exit +100
+exit -100
+exit hello


### PR DESCRIPTION
Put all error messages in stderr instead of stdout and also remove prompt from non tty stdin and remove prompt when redirecting minishell output 